### PR TITLE
Remove SessionsPythonPlugin from CoreKernelService

### DIFF
--- a/SkPluginLibrary/CoreKernelService.KernelBuilder.cs
+++ b/SkPluginLibrary/CoreKernelService.KernelBuilder.cs
@@ -73,8 +73,6 @@ public partial class CoreKernelService
         _nativePlugins.TryAdd(nameof(WebSearchEnginePlugin), webSearchPlugin);
         var searchUrlPlugin = new SearchUrlPlugin();
         _nativePlugins.TryAdd(nameof(SearchUrlPlugin), searchUrlPlugin);
-        var codeInterpreter = new SessionsPythonPlugin(new SessionsPythonSettings(Guid.NewGuid().ToString(),new Uri(_configuration["AzureContainerApps:Endpoint"]!)),_httpClientFactory);
-        _nativePlugins.TryAdd(nameof(SessionsPythonPlugin), codeInterpreter);
         return _nativePlugins;
     }
 


### PR DESCRIPTION
The SessionsPythonPlugin instantiation and its addition to the
_nativePlugins dictionary in CoreKernelService.KernelBuilder.cs
have been removed. This indicates that the SessionsPythonPlugin
is no longer being used or registered as a native plugin in the
CoreKernelService.